### PR TITLE
Changes from IETF 115 Hackathon

### DIFF
--- a/draft-ietf-core-comi.md
+++ b/draft-ietf-core-comi.md
@@ -194,28 +194,29 @@ modifying the content of datastore(s) used for the management of the instrumente
 node.
 
 
-~~~~
+~~~~ aasvg
 +----------------------------------------------------------------+
 |                SMIv2 specification (optional) (2)              |
-+----------------------------------------------------------------+
++------------------------------+---------------------------------+
                                |
-                               V
+                               v
 +----------------------------------------------------------------+
 |                     YANG specification  (1)                    |
-+----------------------------------------------------------------+
++--------+--------------------------------------------+----------+
          |                                            |
-Client   V                               Server       V
-+----------------+                       +-----------------------+
-|        Request |--> CoAP request(3) -->| Indication            |
-|        Confirm |<-- CoAP response(3)<--| Response          (4) |
-|                |                       |                       |
-|                |<==== Security (7) ===>|+---------------------+|
-+----------------+                       || Datastore(s)    (5) ||
-                                         |+---------------------+|
-                                         |+---------------------+|
-                                         || Event stream(s) (6) ||
-                                         |+---------------------+|
-                                         +-----------------------+
+ Client  v                              Server        v
++--------------+                       +-------------------------+
+|      Request +--> CoAP request(3) -->|  Indication             |
+|      Confirm |<-- CoAP response(3)<--+  Response         (4)   |
+|              |                       |                         |
+|              |<==== Security (7) ===>| +---------------------+ |
++--------------+                       | | Datastore(s)    (5) | |
+                                       | +---------------------+ |
+                                       |                         |
+                                       | +---------------------+ |
+                                       | | Event stream(s) (6) | |
+                                       | +---------------------+ |
+                                       +-------------------------+
 ~~~~
 {: #archit title='Abstract CORECONF architecture' artwork-align="left"}
 
@@ -298,16 +299,16 @@ with the least significant 6 bits of the SID represented using an unsigned integ
 
 ~~~~
 SID in base64 = URLsafeChar[SID >> 60 & 0x3F] |
-                 URLsafeChar[SID >> 54 & 0x3F] |
-                 URLsafeChar[SID >> 48 & 0x3F] |
-                 URLsafeChar[SID >> 42 & 0x3F] |
-                 URLsafeChar[SID >> 36 & 0x3F] |
-                 URLsafeChar[SID >> 30 & 0x3F] |
-                 URLsafeChar[SID >> 24 & 0x3F] |
-                 URLsafeChar[SID >> 18 & 0x3F] |
-                 URLsafeChar[SID >> 12 & 0x3F] |
-                 URLsafeChar[SID >> 6 & 0x3F] |
-                 URLsafeChar[SID & 0x3F]
+                URLsafeChar[SID >> 54 & 0x3F] |
+                URLsafeChar[SID >> 48 & 0x3F] |
+                URLsafeChar[SID >> 42 & 0x3F] |
+                URLsafeChar[SID >> 36 & 0x3F] |
+                URLsafeChar[SID >> 30 & 0x3F] |
+                URLsafeChar[SID >> 24 & 0x3F] |
+                URLsafeChar[SID >> 18 & 0x3F] |
+                URLsafeChar[SID >> 12 & 0x3F] |
+                URLsafeChar[SID >> 6 & 0x3F]  |
+                URLsafeChar[SID & 0x3F]
 ~~~~
 {: #Fig-sid-encoding artwork-align="left"}
 

--- a/draft-ietf-core-comi.md
+++ b/draft-ietf-core-comi.md
@@ -1608,19 +1608,6 @@ Reference:    RFC XXXX
 
 // RFC Ed.: please replace XXXX with RFC number and remove this note
 
-# Acknowledgments
-
-We are very grateful to Bert Greevenbosch who was one of the original authors
-of the CORECONF specification.
-
-Mehmet Ersue and Bert Wijnen explained the encoding aspects of PDUs transported
-under SNMP. Carsten Bormann has given feedback on the use of CBOR.
-
-The draft has benefited from comments (alphabetical order) by Rodney Cummings,
-Dee Denteneer, Esko Dijk, Klaus Hartke, Michael van Hartskamp, Tanguy
-Ropitault, Juergen Schoenwaelder, Anuj Sehgal, Zach Shelby, Hannes Tschofenig,
-Michael Verschoor, and Thomas Watteyne.
-
 
 --- back
 
@@ -2080,4 +2067,28 @@ module ietf-coreconf {
 {: artwork-align="left"}
 
 
+# Acknowledgments
+{:unnumbered}
 
+We are very grateful to {{{Bert Greevenbosch}}} who was one of the original authors
+of the CORECONF specification.
+
+{{{Mehmet Ersue}}} and {{{Bert Wijnen}}} explained the encoding aspects of PDUs transported
+under SNMP.
+{{{Koen Zandberg}}}'s implementation input motivated massively simplifying
+(and fixing) the URI construction for GET/PUT/POST requests.
+
+The draft has further benefited from comments (alphabetical order) by
+{{{Rodney Cummings}}},
+{{{Dee Denteneer}}},
+{{{Esko Dijk}}},
+{{{Klaus Hartke}}},
+{{{Michael van Hartskamp}}},
+{{{Tanguy Ropitault}}},
+{{{Jürgen Schönwälder}}},
+{{{Anuj Sehgal}}},
+{{{Zach Shelby}}},
+{{{Hannes Tschofenig}}},
+{{{Michael Verschoor}}},
+and
+{{{Thomas Watteyne}}}.

--- a/draft-ietf-core-comi.md
+++ b/draft-ietf-core-comi.md
@@ -9,6 +9,10 @@ title: CoAP Management Interface (CORECONF)
 abbrev: CORECONF
 area: Applications
 wg: CoRE
+venue:
+  mail: core@ietf.org
+  github: core-wg/comi
+
 author:
 - ins: M. V. Veillette
   role: editor
@@ -48,8 +52,18 @@ author:
   code: '93065'
   country: USA
   email: andy@yumaworks.com
-- role: editor
-  ins: I. I. Petrov
+- name: Carsten Bormann
+  role: editor
+  org: Universität Bremen TZI
+  street: Postfach 330440
+  city: Bremen
+  code: D-28359
+  country: Germany
+  phone: +49-421-218-63921
+  email: cabo@tzi.org
+
+contributor:
+- ins: I. I. Petrov
   name: Ivaylo Petrov
   org: Acklio
   street: 1137A avenue des Champs Blancs
@@ -58,21 +72,20 @@ author:
 #  region: Bretagne
   country: France
   email: ivaylo@ackl.io
+
 normative:
-  RFC2119:
-  RFC3688:
-  RFC8174:
-  RFC4648:
-  RFC5277:
-  RFC6241:
-  RFC6243:
-  RFC8949:
-  RFC7252:
-  RFC7950:
-  RFC7959:
-  RFC7641:
-  RFC8132:
-  RFC8040:
+  RFC3688: xmlreg
+  RFC4648: base
+  RFC5277: nc-notif
+  RFC6241: netconf
+  RFC6243: nc-wd
+  RFC8949: cbor
+  RFC7252: coap
+  RFC7950: yang
+  RFC7959: blockwise
+  RFC7641: observe
+  RFC8132: etch
+  RFC8040: restconf
   RFC9254: yang-cbor
   I-D.ietf-core-sid:
   I-D.ietf-core-yang-library:
@@ -96,12 +109,6 @@ YANG identifier strings to numeric identifiers for payload size reduction.
 CORECONF extends the set of YANG based
 protocols, NETCONF and RESTCONF, with the capability to manage constrained devices
 and networks.
-
---- note_Note
-
-
-Discussion and suggestions for improvement are requested,
-and should be sent to yot@ietf.org.
 
 --- middle
 
@@ -135,16 +142,11 @@ to minimize CBOR payloads and URI length.
 
 ## Terminology {#terminology}
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{RFC2119}} {{RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
-
 The following terms are defined in the YANG data modeling language {{RFC7950}}: action, anydata, anyxml, client, container, data model, data node, identity, instance identifier, leaf, leaf-list, list, module, RPC, schema node, server, submodule.
 
 The following terms are defined in {{RFC6241}}: configuration data, datastore, state data.
 
-The following term is defined in {{I-D.ietf-core-sid}}: YANG schema item identifier (YANG SID, often shorten to simply SID).
+The following term is defined in {{I-D.ietf-core-sid}}: YANG schema item identifier (YANG SID, often shortened to simply SID).
 
 The following terms are defined in the CoAP protocol {{RFC7252}}: Confirmable Message, Content-Format, Endpoint.
 
@@ -181,6 +183,8 @@ instance-identifier:
 instance-value:
 : The value assigned to a data node instance. Instance-values are serialized into
   the payload according to the rules defined in {{Section 4 of -yang-cbor}}.
+
+{::boilerplate bcp14-tagged}
 
 
 # CORECONF Architecture {#comi-architecture}
@@ -594,7 +598,8 @@ data node (i.e. 1723) and the value encoded using a 'text string' as defined in 
 ~~~~
 REQ: GET </c/a7>
 
-RES: 2.05 Content (Content-Format: application/yang-data+cbor; id=sid)
+RES: 2.05 Content
+     (Content-Format: application/yang-data+cbor; id=sid)
 {
   1723 : "2014-10-26T12:16:31Z"
 }
@@ -609,7 +614,8 @@ CBOR map as specified by {{Section 4.2 of -yang-cbor}}.
 ~~~~
 REQ: GET </c/a5>
 
-RES: 2.05 Content (Content-Format: application/yang-data+cbor; id=sid)
+RES: 2.05 Content
+     (Content-Format: application/yang-data+cbor; id=sid)
 {
   1721 : {
     2 : "2014-10-26T12:16:51Z",    / current-datetime (SID 1723) /
@@ -627,7 +633,8 @@ containing 2 instances.
 ~~~~
 REQ: GET </c/X9>
 
-RES: 2.05 Content (Content-Format: application/yang-data+cbor; id=sid)
+RES: 2.05 Content
+     (Content-Format: application/yang-data+cbor; id=sid)
 {
   1533 : [
     {
@@ -657,7 +664,8 @@ is encoded using a CBOR array as specified by {{Section 4.4.1 of -yang-cbor}} co
 ~~~~
 REQ: GET </c/X9?k=eth0>
 
-RES: 2.05 Content (Content-Format: application/yang-data+cbor; id=sid)
+RES: 2.05 Content
+     (Content-Format: application/yang-data+cbor; id=sid)
 {
   1533 : [
     {
@@ -681,7 +689,8 @@ specified by {{Section 6.4 of -yang-cbor}}.
 ~~~~
 REQ: GET </c/X-?k=eth0>
 
-RES: 2.05 Content (Content-Format: application/yang-data+cbor; id=sid)
+RES: 2.05 Content
+     (Content-Format: application/yang-data+cbor; id=sid)
 {
   1534 : "Ethernet adaptor"
 }
@@ -735,12 +744,12 @@ RES: 2.05 Content (Content-Format: application/yang-instances+cbor)
   },
   {
     1533 : {
-       4 : "eth0",                 / name (SID 1537) /
-       1 : "Ethernet adaptor",     / description (SID 1534) /
-       5 : 1880,                   / type (SID 1538), identity /
-                                   / ethernetCsmacd (SID 1880) /
-       2 : true,                   / enabled (SID 1535) /
-      11 : 3                       / oper-status (SID 1544), value is testing /
+       4 : "eth0",              / name (SID 1537) /
+       1 : "Ethernet adaptor",  / description (SID 1534) /
+       5 : 1880,                / type (SID 1538), identity /
+                                / ethernetCsmacd (SID 1880) /
+       2 : true,                / enabled (SID 1535) /
+      11 : 3             / oper-status (SID 1544), value is testing /
     }
   }
 ]
@@ -1007,20 +1016,21 @@ CBOR map with data nodes from these two modules is returned:
 ~~~~
 REQ:  GET </c>
 
-RES: 2.05 Content (Content-Format: application/yang-data+cbor; id=sid)
+RES: 2.05 Content
+     (Content-Format: application/yang-data+cbor; id=sid)
 {
-  1721 : {                       / Clock (SID 1721) /
-    2: "2016-10-26T12:16:31Z",   / current-datetime (SID 1723) /
-    1: "2014-10-05T09:00:00Z"    / boot-datetime (SID 1722) /
+  1721 : {                      / Clock (SID 1721) /
+    2: "2016-10-26T12:16:31Z",  / current-datetime (SID 1723) /
+    1: "2014-10-05T09:00:00Z"   / boot-datetime (SID 1722) /
   },
   1533 : [
-    {                              / interface (SID 1533) /
-       4 : "eth0",                 / name (SID 1537) /
-       1 : "Ethernet adaptor",     / description (SID 1534) /
-       5 : 1880,                   / type (SID 1538), identity: /
-                                   / ethernetCsmacd (SID 1880) /
-       2 : true,                   / enabled (SID 1535) /
-      11 : 3                       / oper-status (SID 1544), value is testing /
+    {                           / interface (SID 1533) /
+       4 : "eth0",              / name (SID 1537) /
+       1 : "Ethernet adaptor",  / description (SID 1534) /
+       5 : 1880,                / type (SID 1538), identity: /
+                                / ethernetCsmacd (SID 1880) /
+       2 : true,                / enabled (SID 1535) /
+      11 : 3             / oper-status (SID 1544), value is testing /
     }
   ]
 }
@@ -1220,7 +1230,8 @@ REQ:  POST </c/Opq?k=myserver>
   }
 }
 
-RES:  2.05 Content (Content-Format: application/yang-data+cbor; id=sid)
+RES:  2.05 Content
+      (Content-Format: application/yang-data+cbor; id=sid)
 {
   60002 : {
     2 : "2016-02-08T14:10:08Z09:18" / reset-finished-at (SID 60004)/
@@ -1459,7 +1470,8 @@ The following 'error-tag' and 'error-app-tag' are defined by the ietf-coreconf Y
 For example, the CORECONF server might return the following error.
 
 ~~~~
-RES:  4.00 Bad Request (Content-Format: application/yang-data+cbor; id=sid)
+RES:  4.00 Bad Request
+     (Content-Format: application/yang-data+cbor; id=sid)
 {
   1024 : {
     4 : 1011,        / error-tag (SID 1028) /
@@ -1610,7 +1622,7 @@ Michael Verschoor, and Thomas Watteyne.
 # ietf-coreconf YANG module {#ietf-coreconf-yang}
 
 ~~~~
-<CODE BEGINS> file "ietf-coreconf@2019-03-28.yang"
+<CODE BEGINS> file "ietf-coreconf@2023-03-13.yang"
 module ietf-coreconf {
   yang-version 1.1;
 
@@ -1662,7 +1674,7 @@ module ietf-coreconf {
      This version of this YANG module is part of RFC XXXX;
      see the RFC itself for full legal notices.";
 
-  revision 2019-03-28 {
+  revision 2023-03-13 {
      description
       "Initial revision.";
     reference
@@ -1691,8 +1703,8 @@ module ietf-coreconf {
   identity invalid-value {
     base error-tag;
     description
-      "Returned by the CORECONF server when the CORECONF client tries to
-       update or create a leaf with a value encoded using an
+      "Returned by the CORECONF server when the CORECONF client tries
+       to update or create a leaf with a value encoded using an
        invalid CBOR datatype or if the 'range', 'length',
        'pattern' or 'require-instance' constrain is not
        fulfilled.";
@@ -1712,8 +1724,8 @@ module ietf-coreconf {
   identity unknown-element {
     base error-tag;
     description
-      "Returned by the CORECONF server when the CORECONF client tries to
-       access a data node of a YANG module not supported, of a
+      "Returned by the CORECONF server when the CORECONF client tries
+       to access a data node of a YANG module not supported, of a
        data node associated with an 'if-feature' expression
        evaluated to 'false' or to a 'when' condition evaluated
        to 'false'.";
@@ -1722,8 +1734,8 @@ module ietf-coreconf {
   identity bad-element {
     base error-tag;
     description
-      "Returned by the CORECONF server when the CORECONF client tries to
-       create data nodes for more than one case in a choice.";
+      "Returned by the CORECONF server when the CORECONF client tries
+       to create data nodes for more than one case in a choice.";
   }
 
   identity data-missing {
@@ -1905,7 +1917,7 @@ module ietf-coreconf {
     }
   ],
   "module-name": "ietf-coreconf",
-  "module-revision": "2019-03-28",
+  "module-revision": "2023-03-13",
   "items": [
     {
       "namespace": "module",

--- a/k.rb
+++ b/k.rb
@@ -1,0 +1,20 @@
+require 'cbor-pure'             # part of "cbor-diag" gem
+require 'base64'
+
+def make_query_parameter(arr)
+  enc = arr.map{ _1.to_cbor}.join
+  Base64.urlsafe_encode64(enc, padding: false)
+end
+
+def print_query_parameter(arr)
+  qp = make_query_parameter(arr)
+  puts "#{arr.inspect} -> #{qp}"
+end
+
+print_query_parameter(["eth0"])
+print_query_parameter(["myserver"])
+# "Simpler" variant:
+print_query_parameter([1533, "eth0"])
+print_query_parameter([60002, "myserver"])
+
+


### PR DESCRIPTION
This PR reflects the discussions at the IETF 115 Hackathon and at the [2023-01-18 CoRE interim][1].

- Simplifies the outer arrays to CBOR sequences (RFC 8742).
- Fixes the comma-separation ambiguity in the URI Query parameter.
- Gets rid of the complexity of (old) Table 6.

[1]: https://datatracker.ietf.org/doc/minutes-interim-2023-core-01-202301181500/#coap-management-interface-comi

This PR is planned to be submitted as -12, for further discussion in the WG.